### PR TITLE
Install specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from ruby:latest
 
-RUN gem install fakes3
+RUN gem install fakes3 -v 0.2.4
 
 EXPOSE 80
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	docker build --force-rm -t tomologic/fakes3 .


### PR DESCRIPTION
To have an excuse to bump fakes3 version we specify in Dockerfile which
version to install. That way we can trigger controlled rebuilds in
Docker Hub when necessary.

Fixes #1 
